### PR TITLE
Add update checker, GitHub link, opacity slider, UI scale, and DPS market bubble

### DIFF
--- a/shared/config_models.py
+++ b/shared/config_models.py
@@ -122,8 +122,11 @@ class SkillConfig:
 class LauncherSettings:
     hotkey_launcher: str = "<shift>+`"
     language: str = "en"
+    scroll_on_hover: bool = False  # scroll wheel adjusts spinboxes/sliders on hover
     grid_rows: int = 3
     grid_cols: int = 2
+    launcher_opacity: float = 0.95  # persisted across sessions
+    ui_scale: float = 1.0  # QT_SCALE_FACTOR for high-DPI monitors (0.75 – 3.0)
     disabled_skills: list[str] = field(default_factory=list)
     grid_layout: dict[str, str] = field(default_factory=dict)  # "row,col" -> skill_id
     skill_hotkeys: dict[str, str] = field(default_factory=dict)
@@ -134,8 +137,11 @@ class LauncherSettings:
     def from_dict(cls, data: dict[str, Any], skills: list[SkillConfig]) -> LauncherSettings:
         hotkey_launcher = str(data.get("hotkey_launcher", "<shift>+`"))
         language = str(data.get("language", "en"))
+        scroll_on_hover = bool(data.get("scroll_on_hover", False))
         grid_rows = _clamp(_safe_int(data.get("grid_rows", 3), 3), 1, 10)
         grid_cols = _clamp(_safe_int(data.get("grid_cols", 2), 2), 1, 10)
+        launcher_opacity = max(0.3, min(1.0, _safe_float(data.get("launcher_opacity", 0.95), 0.95)))
+        ui_scale = max(0.75, min(3.0, _safe_float(data.get("ui_scale", 1.0), 1.0)))
         disabled_skills = list(data.get("disabled_skills", []))
         grid_layout = dict(data.get("grid_layout", {}))
 
@@ -151,8 +157,11 @@ class LauncherSettings:
         return cls(
             hotkey_launcher=hotkey_launcher,
             language=language,
+            scroll_on_hover=scroll_on_hover,
             grid_rows=grid_rows,
             grid_cols=grid_cols,
+            launcher_opacity=launcher_opacity,
+            ui_scale=ui_scale,
             disabled_skills=disabled_skills,
             grid_layout=grid_layout,
             skill_hotkeys=skill_hotkeys,
@@ -165,8 +174,11 @@ class LauncherSettings:
         out = dict(self.raw)
         out["hotkey_launcher"] = self.hotkey_launcher
         out["language"] = self.language
+        out["scroll_on_hover"] = self.scroll_on_hover
         out["grid_rows"] = self.grid_rows
         out["grid_cols"] = self.grid_cols
+        out["launcher_opacity"] = self.launcher_opacity
+        out["ui_scale"] = self.ui_scale
         out["disabled_skills"] = self.disabled_skills
         out["grid_layout"] = self.grid_layout
         for sid, hk in self.skill_hotkeys.items():

--- a/shared/ipc.py
+++ b/shared/ipc.py
@@ -86,6 +86,13 @@ def _open_lock(lock_path: str):
     if lf.tell() == 0:
         lf.write(b'\x00')
         lf.flush()
+    else:
+        # Refresh mtime so _recover_stale_lock doesn't treat an actively-used
+        # lock file as orphaned just because no new bytes were written.
+        try:
+            os.utime(lock_path, None)
+        except OSError:
+            pass
     return lf
 
 

--- a/shared/qt/title_bar.py
+++ b/shared/qt/title_bar.py
@@ -8,10 +8,10 @@ drag-to-move, and compact window controls.
 from __future__ import annotations
 from typing import Callable, List, Optional, Tuple
 
-from PySide6.QtCore import Qt, QPoint, Signal
+from PySide6.QtCore import Qt, QPoint, QTimer, Signal
 from PySide6.QtGui import QFont, QPainter, QPen, QColor, QLinearGradient
 from PySide6.QtWidgets import (
-    QWidget, QHBoxLayout, QLabel, QPushButton,
+    QWidget, QHBoxLayout, QLabel, QPushButton, QSlider,
 )
 
 from shared.qt.theme import P
@@ -123,6 +123,60 @@ class SCTitleBar(QWidget):
 
         layout.addStretch(1)
 
+        # Opacity slider
+        opacity_icon = QLabel("\u25C9", self)  # ◉ circle icon
+        opacity_icon.setStyleSheet(f"""
+            font-size: 8pt;
+            color: {P.fg_dim};
+            background: transparent;
+            padding: 0px 2px;
+        """)
+        opacity_icon.setToolTip("Window Opacity")
+        layout.addWidget(opacity_icon)
+
+        self._opacity_slider = QSlider(Qt.Horizontal, self)
+        self._opacity_slider.setRange(30, 100)
+        self._opacity_slider.setValue(
+            int(window.windowOpacity() * 100) if hasattr(window, "windowOpacity") else 95
+        )
+        self._opacity_slider.setFixedWidth(80)
+        self._opacity_slider.setFixedHeight(20)
+        self._opacity_slider.setCursor(Qt.PointingHandCursor)
+        self._opacity_slider.setToolTip("Adjust window opacity")
+        self._opacity_slider.setStyleSheet(f"""
+            QSlider::groove:horizontal {{
+                background: rgba(90, 100, 128, 0.3);
+                height: 4px;
+                border-radius: 2px;
+            }}
+            QSlider::handle:horizontal {{
+                background: {self._accent};
+                width: 10px;
+                height: 10px;
+                margin: -3px 0;
+                border-radius: 5px;
+            }}
+            QSlider::handle:horizontal:hover {{
+                background: {P.fg_bright};
+            }}
+            QSlider::sub-page:horizontal {{
+                background: {self._accent};
+                border-radius: 2px;
+            }}
+        """)
+        # Debounce: apply opacity only after the user stops moving the slider
+        # for 100 ms.  Calling setWindowOpacity on every valueChanged tick
+        # triggers a DWM recomposition on Windows (WA_TranslucentBackground),
+        # which causes visible rapid flickering.
+        self._opacity_timer = QTimer(self)
+        self._opacity_timer.setSingleShot(True)
+        self._opacity_timer.setInterval(100)
+        self._opacity_timer.timeout.connect(self._apply_opacity)
+        self._pending_opacity: float = self._opacity_slider.value() / 100.0
+
+        self._opacity_slider.valueChanged.connect(self._on_opacity_slider_moved)
+        layout.addWidget(self._opacity_slider)
+
         # Extra buttons (e.g. Patreon link)
         for btn_text, btn_cb in (extra_buttons or []):
             eb = QPushButton(btn_text, self)
@@ -154,6 +208,16 @@ class SCTitleBar(QWidget):
         btn_close = _TitleButton("x", "rgba(220, 50, 50, 0.85)", self, is_close=True)
         btn_close.clicked.connect(self.close_clicked.emit)
         layout.addWidget(btn_close)
+
+    def _on_opacity_slider_moved(self, value: int) -> None:
+        self._pending_opacity = value / 100.0
+        self._opacity_timer.start()
+
+    def _apply_opacity(self) -> None:
+        if hasattr(self._window, "set_opacity"):
+            self._window.set_opacity(self._pending_opacity)
+        else:
+            self._window.setWindowOpacity(max(0.3, min(1.0, self._pending_opacity)))
 
     def set_hotkey(self, text: str) -> None:
         if self._hotkey_label:

--- a/skill_launcher.py
+++ b/skill_launcher.py
@@ -96,6 +96,11 @@ class SCToolboxApp:
         raw_settings = _load_settings_raw()
         self._settings = LauncherSettings.from_dict(raw_settings, self._skills)
 
+        # ── Restore saved launcher opacity ──
+        # The CLI arg carries whatever WingmanAI last passed; override it with
+        # the opacity the user set via the title-bar slider (persisted on exit).
+        geometry.opacity = self._settings.launcher_opacity
+
         # ── Initialise i18n ──
         i18n.init(self._settings.language, os.path.join(_skill_dir, "locales"))
 
@@ -117,7 +122,11 @@ class SCToolboxApp:
 
         # Determine availability and register processes
         self._availability: Dict[str, bool] = {}
-        lang_env = {"SC_TOOLBOX_LANG": self._settings.language}
+        lang_env = {
+            "SC_TOOLBOX_LANG": self._settings.language,
+        }
+        if self._settings.ui_scale != 1.0:
+            lang_env["QT_SCALE_FACTOR"] = str(self._settings.ui_scale)
         for skill in self._skills:
             script_path = resolve_script_path(skill, _skill_dir)
             available = script_path is not None
@@ -157,6 +166,8 @@ class SCToolboxApp:
             grid_rows=self._settings.grid_rows,
             grid_cols=self._settings.grid_cols,
             grid_layout=self._settings.grid_layout,
+            scroll_on_hover=self._settings.scroll_on_hover,
+            ui_scale=self._settings.ui_scale,
         )
 
         # ── Thread-safe dispatch queue ──
@@ -250,10 +261,17 @@ class SCToolboxApp:
                     lambda s=s: self._toggle_skill(s))
         return bindings
 
-    def _apply_settings(self, settings_dict: dict) -> None:
-        """Called by the settings popup when Apply & Restart is clicked.
+    def _save_launcher_opacity(self) -> None:
+        """Persist the current window opacity to the settings file."""
+        self._settings.launcher_opacity = self._window.windowOpacity()
+        _save_settings_raw(self._settings.to_dict())
 
-        Saves all settings to disk and relaunches the launcher process.
+    def _apply_settings(self, settings_dict: dict) -> None:
+        """Called by the settings popup when Apply is clicked.
+
+        Saves all settings to disk and rebuilds the UI in-place.
+        Only does a full process relaunch when QT_SCALE_FACTOR changes
+        (since that must be set before QApplication creation).
         """
         # Update hotkeys
         new_launcher = settings_dict.get("hotkey_launcher", self._launcher_hotkey)
@@ -276,16 +294,89 @@ class SCToolboxApp:
         # Update disabled skills
         self._settings.disabled_skills = settings_dict.get("disabled_skills", [])
 
+        # Update scroll on hover
+        self._settings.scroll_on_hover = settings_dict.get("scroll_on_hover", self._settings.scroll_on_hover)
+
         # Update language
         new_lang = settings_dict.get("language", self._settings.language)
         self._settings.language = new_lang
         self._settings.raw["language"] = new_lang
 
+        # Update UI scale
+        old_scale = self._settings.ui_scale
+        self._settings.ui_scale = settings_dict.get("ui_scale", self._settings.ui_scale)
+
+        # Capture current opacity so it survives
+        self._settings.launcher_opacity = self._window.windowOpacity()
+
         # Save to disk
         _save_settings_raw(self._settings.to_dict())
 
-        # Relaunch
-        self._relaunch()
+        # UI scale requires a full process restart (QT_SCALE_FACTOR is read
+        # once at QApplication creation).  Everything else can be rebuilt
+        # in-place without the flicker of spawning a new process.
+        if self._settings.ui_scale != old_scale:
+            self._relaunch()
+        else:
+            self._rebuild_ui()
+
+    def _rebuild_ui(self) -> None:
+        """Tear down and recreate the window + hotkeys without spawning a new
+        process.  This is nearly instant compared to a full relaunch."""
+        # Remember position / size / opacity of the current window
+        pos = self._window.pos()
+        size = self._window.size()
+        opacity = self._window.windowOpacity()
+
+        # Stop hotkeys (will be re-bound below)
+        self._stop_hotkeys()
+
+        # Reload i18n in case language changed
+        i18n.init(self._settings.language, os.path.join(_skill_dir, "locales"))
+
+        # Update the launcher hotkey reference
+        self._launcher_hotkey = self._settings.hotkey_launcher
+
+        # Close the old window (doesn't quit the app)
+        self._window.close()
+
+        # Build a fresh geometry from the old position
+        geom = WindowGeometry(
+            x=pos.x(), y=pos.y(),
+            w=size.width(), h=size.height(),
+            opacity=opacity,
+        )
+
+        # Create the new window
+        self._window = LauncherWindow(
+            geometry=geom,
+            skills=self._skills,
+            availability=self._availability,
+            launcher_hotkey=self._launcher_hotkey,
+            python_info=self._python_info,
+            on_toggle_skill=self._toggle_skill,
+            on_apply_settings=self._apply_settings,
+            on_shutdown=self._shutdown,
+            current_language=self._settings.language,
+            available_languages=i18n.available_languages(_skill_dir),
+            disabled_skills=self._settings.disabled_skills,
+            grid_rows=self._settings.grid_rows,
+            grid_cols=self._settings.grid_cols,
+            grid_layout=self._settings.grid_layout,
+            scroll_on_hover=self._settings.scroll_on_hover,
+            ui_scale=self._settings.ui_scale,
+        )
+
+        # Restore tile states for any skills that are already running
+        for skill in self._skills:
+            mp = self._pm.get(skill.id)
+            if mp:
+                self._window.update_tile(skill.id, mp.running, mp.visible)
+
+        self._window.show()
+
+        # Restart hotkeys with updated bindings
+        self._start_hotkeys()
 
     def _relaunch(self) -> None:
         """Stop everything and spawn a fresh launcher process, then quit."""
@@ -322,13 +413,16 @@ class SCToolboxApp:
             logger.error("Failed to relaunch: %s", exc)
             return
 
-        # Quit the current process
+        # Quit the current process.
+        # Delay close/quit by ~400ms to give the new process time to show its
+        # window before ours disappears, reducing the visible blank gap.
         self._running.clear()
         self._queue_timer.stop()
-        self._window.close()
+        self._window.setEnabled(False)
+        QTimer.singleShot(400, self._window.close)
         app = QApplication.instance()
         if app:
-            app.quit()
+            QTimer.singleShot(500, app.quit)
 
     # ── IPC command watcher ──────────────────────────────────────────────
 
@@ -389,6 +483,7 @@ class SCToolboxApp:
     # ── Shutdown ─────────────────────────────────────────────────────────
 
     def _shutdown(self) -> None:
+        self._save_launcher_opacity()
         self._running.clear()
         self._queue_timer.stop()
         self._stop_hotkeys()
@@ -433,6 +528,16 @@ def main() -> None:
         opacity=_float(4, 0.95),
     )
     cmd_file = args[5] if len(args) > 5 else os.devnull
+
+    # Apply UI scale factor before QApplication is created
+    raw = _load_settings_raw()
+    ui_scale = raw.get("ui_scale", 1.0)
+    try:
+        ui_scale = max(0.75, min(3.0, float(ui_scale)))
+    except (TypeError, ValueError):
+        ui_scale = 1.0
+    if ui_scale != 1.0:
+        os.environ["QT_SCALE_FACTOR"] = str(ui_scale)
 
     # Create QApplication first (required before any Qt widgets)
     qt_app = QApplication(sys.argv)

--- a/skills/Cargo_loader/cargo_app.py
+++ b/skills/Cargo_loader/cargo_app.py
@@ -1040,7 +1040,7 @@ onto your Star Citizen ship before you undock.</p>
       commodities onto individual boxes.</li>
 </ol>
 
-<p style="color:#5a6480;font-size:8pt">Data sourced from sc-cargo.space — click ⟳ in the header to refresh.</p>
+<p style="color:#5a6480;font-size:8pt">Data sourced from sc-cargo.space — click ↻ in the header to refresh.</p>
 """,
         # ── Ship & View ───────────────────────────────────────────────────────
         """
@@ -1050,7 +1050,7 @@ onto your Star Citizen ship before you undock.</p>
 <ul>
   <li>Type any part of the ship name — results filter as you type.</li>
   <li>Click <b>▼</b> to browse the full list without typing.</li>
-  <li>Click <b style="color:#5a6480">⟳</b> to fetch the latest ship &amp; capacity data.</li>
+  <li>Click <b style="color:#5a6480">↻</b> to fetch the latest ship &amp; capacity data.</li>
 </ul>
 
 <b style="color:#c8d4e8">Isometric View</b>
@@ -1333,7 +1333,7 @@ class CargoApp(SCWindow):
         self._ship_combo.item_selected.connect(self._load_ship)
         hdr_lay.addWidget(self._ship_combo)
 
-        self._btn_refresh = QPushButton("\u27f3", hdr)
+        self._btn_refresh = QPushButton("\u21bb", hdr)
         btn_refresh = self._btn_refresh
         btn_refresh.setFixedSize(32, 28)
         btn_refresh.setCursor(Qt.PointingHandCursor)
@@ -1508,30 +1508,55 @@ class CargoApp(SCWindow):
         """Build the assignments summary overlay pinned to the top-left of the iso view."""
         overlay = QWidget(self._view.viewport())
         overlay.setAttribute(Qt.WA_TransparentForMouseEvents, True)
-        overlay.setFixedWidth(170)
+        overlay.setFixedWidth(182)
+        # More opaque so text composites against a near-solid surface (avoids ClearType blur)
         overlay.setStyleSheet(
-            f"background-color: rgba(11, 14, 20, 210); border: 1px solid {BORDER};"
+            f"background-color: rgba(9, 12, 18, 235); border: 1px solid {P.tool_cargo};"
         )
 
         lay = QVBoxLayout(overlay)
-        lay.setContentsMargins(8, 6, 8, 6)
-        lay.setSpacing(3)
+        lay.setContentsMargins(10, 7, 10, 8)
+        lay.setSpacing(4)
 
-        sum_lbl = QLabel(_("ASSIGNMENTS"), overlay)
+        # Header: accent bar + label
+        hdr_row = QWidget(overlay)
+        hdr_row.setStyleSheet("background: transparent;")
+        hdr_lay = QHBoxLayout(hdr_row)
+        hdr_lay.setContentsMargins(0, 0, 0, 0)
+        hdr_lay.setSpacing(6)
+
+        bar = QWidget(hdr_row)
+        bar.setFixedSize(3, 14)
+        bar.setStyleSheet(f"background-color: {P.tool_cargo}; border: none;")
+        hdr_lay.addWidget(bar)
+
+        sum_lbl = QLabel("ASSIGNMENTS", hdr_row)
         sum_lbl.setStyleSheet(
-            f"color: {ACCENT}; font-family: Electrolize, Consolas; font-size: 8pt; "
-            f"font-weight: bold; background: transparent;"
+            f"color: {P.tool_cargo}; font-family: Electrolize, Consolas; font-size: 9pt; "
+            f"font-weight: bold; letter-spacing: 1px; background: transparent;"
         )
-        lay.addWidget(sum_lbl)
+        hdr_lay.addWidget(sum_lbl)
+        hdr_lay.addStretch(1)
+        lay.addWidget(hdr_row)
 
-        self._assignment_summary_lbl = QLabel(
-            "No assignments yet.\nClick boxes to assign commodities.", overlay
-        )
+        # Thin separator line under header
+        sep = QFrame(overlay)
+        sep.setFrameShape(QFrame.HLine)
+        sep.setStyleSheet(f"color: {P.tool_cargo}; background: transparent;")
+        sep.setFixedHeight(1)
+        lay.addWidget(sep)
+        lay.addSpacing(1)
+
+        self._assignment_summary_lbl = QLabel(overlay)
         self._assignment_summary_lbl.setStyleSheet(
-            f"color: {FG_DIM}; font-family: Consolas; font-size: 7pt; "
+            f"color: {FG_DIM}; font-family: Consolas; font-size: 8pt; "
             f"background: transparent;"
         )
         self._assignment_summary_lbl.setWordWrap(True)
+        self._assignment_summary_lbl.setText(
+            f"<span style='color:{FG_DIM}'>No assignments yet.<br>"
+            f"Click boxes to assign commodities.</span>"
+        )
         lay.addWidget(self._assignment_summary_lbl)
 
         overlay.adjustSize()

--- a/skills/DPS_Calculator/dps_ui/market_bubble.py
+++ b/skills/DPS_Calculator/dps_ui/market_bubble.py
@@ -1,0 +1,405 @@
+"""Market price bubble — queries UEX for buy/sell prices of a component."""
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+import re
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Optional
+
+from PySide6.QtCore import Qt, QPoint, Signal, QObject
+from PySide6.QtGui import QColor, QPainter, QPen
+from PySide6.QtWidgets import (
+    QAbstractItemView, QDialog, QHBoxLayout, QHeaderView, QLabel,
+    QPushButton, QTableWidget, QTableWidgetItem, QVBoxLayout, QWidget,
+)
+
+from dps_ui.constants import (
+    ACCENT, BG, BG2, BG3, BORDER, FG, FG_DIM, GREEN, HEADER_BG, ORANGE, YELLOW,
+)
+from shared.qt.theme import P
+
+log = logging.getLogger(__name__)
+
+_UEX_BASE = "https://api.uexcorp.space/2.0"
+_UEX_HEADERS = {"User-Agent": "DPS_Calculator/1.0", "Accept": "application/json"}
+_MAX_BUBBLES = 5
+
+# UEX category IDs for each Erkul item type
+_TYPE_CATS: dict[str, list[int]] = {
+    "WeaponGun":       [32, 35],   # Guns, Turrets
+    "MissileLauncher": [33, 34],   # Missile Racks, Missiles
+    "Shield":          [23],       # Shield Generators
+    "Cooler":          [19],       # Coolers
+    "PowerPlant":      [21],       # Power Plants
+    "QuantumDrive":    [22],       # Quantum Drives
+    "Radar":           [83],       # Radar
+}
+# Fallback: try all ship-relevant categories
+_ALL_SHIP_CATS = [19, 21, 22, 23, 32, 33, 34, 35, 83]
+
+# Class-level category item cache (shared across all bubbles in session)
+_cat_cache: dict[int, list] = {}
+_cat_cache_lock = threading.Lock()
+
+
+def _norm(name: str) -> str:
+    """Strip quotes, lowercase, collapse whitespace for fuzzy matching."""
+    return re.sub(r"\s+", " ", re.sub(r"['\"]", "", name)).strip().lower()
+
+
+def _name_matches(erkul: str, uex: str) -> bool:
+    e, u = _norm(erkul), _norm(uex)
+    return e in u or u in e
+
+
+def _pin_qss(pinned: bool) -> str:
+    c = ACCENT
+    if pinned:
+        return f"""
+            QPushButton#mktPin {{
+                background-color: rgba(51,221,136,80); color: {P.bg_primary};
+                border: 1px solid {c}; border-radius: 3px;
+                font-family: Consolas; font-size: 8pt; font-weight: bold;
+                padding: 3px 10px; min-height: 0px;
+            }}
+            QPushButton#mktPin:hover {{ background-color: rgba(51,221,136,50); color: {c}; }}
+        """
+    return f"""
+        QPushButton#mktPin {{
+            background-color: rgba(51,221,136,30); color: {c};
+            border: 1px solid rgba(51,221,136,60); border-radius: 3px;
+            font-family: Consolas; font-size: 8pt; font-weight: bold;
+            padding: 3px 10px; min-height: 0px;
+        }}
+        QPushButton#mktPin:hover {{ background-color: rgba(51,221,136,60); color: {P.fg_bright}; }}
+    """
+
+
+class _FetchSignals(QObject):
+    done = Signal(list)
+    error = Signal(str)
+
+
+class MarketBubble(QDialog):
+    """Draggable, pinnable UEX market price popup.
+
+    Opens as a non-modal, always-on-top window. Up to _MAX_BUBBLES are kept
+    open simultaneously; the oldest unpinned bubble is evicted when the limit
+    is reached. Pin keeps a bubble open regardless.
+    """
+
+    _open: list[MarketBubble] = []
+    _pinned: list[MarketBubble] = []
+
+    def __init__(self, parent: Optional[QWidget], item: dict):
+        super().__init__(parent)
+        self._item = item
+        self._name = item.get("name", "Unknown")
+        self._is_pinned = False
+        self._drag_pos: Optional[QPoint] = None
+        self._sig = _FetchSignals()
+        self._sig.done.connect(self._on_prices)
+        self._sig.error.connect(self._on_error)
+
+        self.setWindowFlags(Qt.Tool | Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint)
+        self.setAttribute(Qt.WA_TranslucentBackground, True)
+        self.setFixedSize(580, 360)
+
+        self._evict_oldest()
+        MarketBubble._open.append(self)
+
+        if parent:
+            pg = parent.geometry()
+            self.move(max(0, pg.x() + 50), max(0, pg.y() + 80))
+
+        self._build_ui()
+        threading.Thread(target=self._fetch, daemon=True).start()
+
+    # ── UI ────────────────────────────────────────────────────────────────────
+
+    def _build_ui(self):
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(1, 1, 1, 1)
+        outer.setSpacing(0)
+
+        frame = QWidget(self)
+        frame.setStyleSheet("background-color: rgba(11,14,20,230);")
+        fl = QVBoxLayout(frame)
+        fl.setContentsMargins(0, 0, 0, 0)
+        fl.setSpacing(0)
+
+        # ── Header ──
+        hdr = QWidget(frame)
+        hdr.setFixedHeight(34)
+        hdr.setStyleSheet(f"background-color: {HEADER_BG};")
+        hl = QHBoxLayout(hdr)
+        hl.setContentsMargins(12, 0, 4, 0)
+        hl.setSpacing(8)
+
+        title = QLabel(f"\U0001f6d2  {self._name.upper()}", hdr)
+        title.setStyleSheet(f"""
+            font-family: Electrolize, Consolas, monospace;
+            font-size: 10pt; font-weight: bold;
+            color: {ACCENT}; letter-spacing: 1px; background: transparent;
+        """)
+        hl.addWidget(title)
+        hl.addStretch(1)
+
+        self._pin_btn = QPushButton("Pin", hdr)
+        self._pin_btn.setObjectName("mktPin")
+        self._pin_btn.setCursor(Qt.PointingHandCursor)
+        self._pin_btn.setStyleSheet(_pin_qss(False))
+        self._pin_btn.clicked.connect(self._toggle_pin)
+        hl.addWidget(self._pin_btn)
+
+        close_btn = QPushButton("x", hdr)
+        close_btn.setObjectName("mktClose")
+        close_btn.setFixedSize(32, 28)
+        close_btn.setCursor(Qt.PointingHandCursor)
+        close_btn.setStyleSheet("""
+            QPushButton#mktClose {
+                background: rgba(255,60,60,0.15); color: #cc6666;
+                border: none; border-radius: 3px;
+                font-family: Consolas; font-size: 13pt; font-weight: bold;
+                padding: 0px; margin: 2px; min-height: 0px;
+            }
+            QPushButton#mktClose:hover {
+                background-color: rgba(220,50,50,0.85); color: #ffffff;
+            }
+        """)
+        close_btn.clicked.connect(self.close)
+        hl.addWidget(close_btn)
+        fl.addWidget(hdr)
+
+        # ── Status bar ──
+        self._status = QLabel("  Searching UEX marketplace...", frame)
+        self._status.setStyleSheet(f"""
+            color: {FG_DIM}; font-family: Consolas; font-size: 9pt;
+            background: {BG2}; padding: 5px 12px;
+            border-bottom: 1px solid {BORDER};
+        """)
+        fl.addWidget(self._status)
+
+        # ── Price table ──
+        self._table = QTableWidget(0, 5, frame)
+        self._table.setHorizontalHeaderLabels(
+            ["Location", "Terminal", "Buy aUEC", "Sell aUEC", "Updated"]
+        )
+        self._table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self._table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self._table.setSelectionMode(QAbstractItemView.SingleSelection)
+        self._table.setShowGrid(False)
+        self._table.verticalHeader().setVisible(False)
+        self._table.horizontalHeader().setStretchLastSection(True)
+        self._table.horizontalHeader().setSectionResizeMode(0, QHeaderView.Stretch)
+        self._table.horizontalHeader().setSectionResizeMode(1, QHeaderView.Stretch)
+        self._table.setAlternatingRowColors(True)
+        self._table.setStyleSheet(f"""
+            QTableWidget {{
+                background-color: {BG};
+                alternate-background-color: {BG3};
+                color: {FG}; border: none;
+                font-family: Consolas; font-size: 9pt;
+                selection-background-color: #1e2840;
+                selection-color: {FG}; outline: none;
+            }}
+            QTableWidget::item {{ padding: 3px 6px; }}
+            QHeaderView::section {{
+                background-color: {HEADER_BG}; color: {FG_DIM};
+                border: none; border-bottom: 1px solid {BORDER};
+                padding: 4px 6px;
+                font-family: Consolas; font-size: 8pt; font-weight: bold;
+            }}
+        """)
+        fl.addWidget(self._table, 1)
+        outer.addWidget(frame)
+
+    # ── Fetch (background thread) ─────────────────────────────────────────────
+
+    def _fetch(self):
+        item_type = self._item.get("type", "")
+        cats = _TYPE_CATS.get(item_type, _ALL_SHIP_CATS)
+        try:
+            item_id = self._find_id_in_categories(cats)
+            if item_id is None and cats is not _ALL_SHIP_CATS:
+                # Widen search to all ship categories
+                item_id = self._find_id_in_categories(_ALL_SHIP_CATS)
+            if item_id is None:
+                self._sig.error.emit(f"'{self._name}' not found in UEX marketplace.")
+                return
+
+            prices = self._fetch_prices(item_id)
+            if prices:
+                self._sig.done.emit(prices)
+            else:
+                self._sig.error.emit(f"No active listings for '{self._name}' in UEX.")
+
+        except (urllib.error.URLError, OSError, TimeoutError) as exc:
+            self._sig.error.emit(f"Network error: {exc}")
+        except (json.JSONDecodeError, ValueError) as exc:
+            self._sig.error.emit(f"Parse error: {exc}")
+
+    def _find_id_in_categories(self, cat_ids: list[int]) -> int | None:
+        for cid in cat_ids:
+            items = self._get_category(cid)
+            for it in items:
+                if _name_matches(self._name, it.get("name", "")):
+                    log.debug(
+                        "Matched '%s' → UEX '%s' (id=%s, cat=%s)",
+                        self._name, it.get("name"), it.get("id"), cid,
+                    )
+                    return it.get("id")
+        return None
+
+    @staticmethod
+    def _get_category(cid: int) -> list:
+        """Fetch items for a UEX category, using class-level cache."""
+        with _cat_cache_lock:
+            if cid in _cat_cache:
+                return _cat_cache[cid]
+        url = f"{_UEX_BASE}/items?id_category={cid}"
+        req = urllib.request.Request(url, headers=_UEX_HEADERS)
+        with urllib.request.urlopen(req, timeout=10) as r:
+            body = json.loads(r.read().decode())
+        items: list = []
+        if isinstance(body, dict) and body.get("status") == "ok":
+            data = body.get("data") or []
+            items = data if isinstance(data, list) else []
+        with _cat_cache_lock:
+            _cat_cache[cid] = items
+        return items
+
+    @staticmethod
+    def _fetch_prices(item_id: int) -> list:
+        url = f"{_UEX_BASE}/items_prices?id_item={item_id}"
+        req = urllib.request.Request(url, headers=_UEX_HEADERS)
+        with urllib.request.urlopen(req, timeout=10) as r:
+            body = json.loads(r.read().decode())
+        if isinstance(body, dict) and body.get("status") == "ok":
+            data = body.get("data") or []
+            return data if isinstance(data, list) else []
+        return []
+
+    # ── Slots (Qt main thread) ────────────────────────────────────────────────
+
+    def _on_prices(self, prices: list):
+        self._table.setRowCount(0)
+        for entry in prices:
+            row = self._table.rowCount()
+            self._table.insertRow(row)
+
+            planet = entry.get("planet_name") or entry.get("star_system_name") or "—"
+            city = entry.get("city_name") or ""
+            location = f"{planet} › {city}" if city else planet
+            terminal = entry.get("terminal_name") or "—"
+            buy = entry.get("price_buy") or 0
+            sell = entry.get("price_sell") or 0
+            ts = entry.get("date_modified") or entry.get("date_added") or 0
+            updated = (
+                datetime.datetime.fromtimestamp(ts).strftime("%Y-%m-%d") if ts else "—"
+            )
+
+            def _cell(text, color=FG, align=Qt.AlignLeft | Qt.AlignVCenter):
+                c = QTableWidgetItem(str(text))
+                c.setForeground(QColor(color))
+                c.setTextAlignment(align)
+                c.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)
+                return c
+
+            R = Qt.AlignRight | Qt.AlignVCenter
+            self._table.setItem(row, 0, _cell(location))
+            self._table.setItem(row, 1, _cell(terminal))
+            self._table.setItem(row, 2, _cell(f"{buy:,.0f}" if buy else "—", GREEN, R))
+            self._table.setItem(row, 3, _cell(f"{sell:,.0f}" if sell else "—", YELLOW, R))
+            self._table.setItem(row, 4, _cell(updated, FG_DIM))
+
+        self._status.setText(f"  {len(prices)} listing(s) — UEX marketplace")
+        self._status.setStyleSheet(f"""
+            color: {FG_DIM}; font-family: Consolas; font-size: 9pt;
+            background: {BG2}; padding: 5px 12px;
+            border-bottom: 1px solid {BORDER};
+        """)
+
+    def _on_error(self, msg: str):
+        self._status.setText(f"  {msg}")
+        self._status.setStyleSheet(f"""
+            color: {ORANGE}; font-family: Consolas; font-size: 9pt;
+            background: {BG2}; padding: 5px 12px;
+            border-bottom: 1px solid {BORDER};
+        """)
+
+    # ── Pin ───────────────────────────────────────────────────────────────────
+
+    def _toggle_pin(self):
+        self._is_pinned = not self._is_pinned
+        self._pin_btn.setText("Unpin" if self._is_pinned else "Pin")
+        self._pin_btn.setStyleSheet(_pin_qss(self._is_pinned))
+        if self._is_pinned:
+            if self not in MarketBubble._pinned:
+                MarketBubble._pinned.append(self)
+        else:
+            if self in MarketBubble._pinned:
+                MarketBubble._pinned.remove(self)
+
+    # ── Eviction ──────────────────────────────────────────────────────────────
+
+    @classmethod
+    def _evict_oldest(cls):
+        cls._open = [d for d in cls._open if d.isVisible()]
+        cls._pinned = [d for d in cls._pinned if d.isVisible()]
+        while len(cls._open) >= _MAX_BUBBLES:
+            victim = next((d for d in cls._open if not d._is_pinned), None)
+            if victim is None:
+                victim = cls._open[0]
+            victim.close()
+
+    # ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    def closeEvent(self, event):
+        if self in MarketBubble._open:
+            MarketBubble._open.remove(self)
+        if self in MarketBubble._pinned:
+            MarketBubble._pinned.remove(self)
+        super().closeEvent(event)
+
+    # ── Paint (border + corner brackets) ─────────────────────────────────────
+
+    def paintEvent(self, event):
+        super().paintEvent(event)
+        p = QPainter(self)
+        p.setRenderHint(QPainter.Antialiasing, False)
+        w, h = self.width(), self.height()
+        edge = QColor(ACCENT)
+        edge.setAlpha(100)
+        p.setPen(QPen(edge, 1))
+        p.drawRect(0, 0, w - 1, h - 1)
+        bl = 12
+        brk = QColor(ACCENT)
+        brk.setAlpha(200)
+        p.setPen(QPen(brk, 2))
+        p.drawLine(0, 0, bl, 0);      p.drawLine(0, 0, 0, bl)
+        p.drawLine(w-1, 0, w-1-bl, 0); p.drawLine(w-1, 0, w-1, bl)
+        p.drawLine(0, h-1, bl, h-1);   p.drawLine(0, h-1, 0, h-1-bl)
+        p.drawLine(w-1, h-1, w-1-bl, h-1); p.drawLine(w-1, h-1, w-1, h-1-bl)
+        p.end()
+
+    # ── Drag ─────────────────────────────────────────────────────────────────
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.LeftButton:
+            self._drag_pos = event.globalPosition().toPoint() - self.pos()
+            event.accept()
+
+    def mouseMoveEvent(self, event):
+        if self._drag_pos is not None and event.buttons() & Qt.LeftButton:
+            self.move(event.globalPosition().toPoint() - self._drag_pos)
+            event.accept()
+
+    def mouseReleaseEvent(self, event):
+        self._drag_pos = None
+        super().mouseReleaseEvent(event)

--- a/skills/DPS_Calculator/dps_ui/widgets.py
+++ b/skills/DPS_Calculator/dps_ui/widgets.py
@@ -118,6 +118,22 @@ class ComponentTable(QWidget):
 
         row_lay.addStretch(1)
 
+        if item:
+            cart_btn = QPushButton("\U0001f6d2", container)
+            cart_btn.setFixedSize(22, 22)
+            cart_btn.setToolTip("Check UEX market price")
+            cart_btn.setCursor(Qt.PointingHandCursor)
+            cart_btn.setStyleSheet(f"""
+                QPushButton {{
+                    background: transparent; color: {FG_DIM};
+                    border: none; font-size: 10pt; padding: 0px;
+                }}
+                QPushButton:hover {{ color: {ACCENT}; }}
+            """)
+            _it = item
+            cart_btn.clicked.connect(lambda checked=False, it=_it: self._open_market(it))
+            row_lay.addWidget(cart_btn)
+
         arrow = QLabel("\u25bc", container)
         arrow.setStyleSheet(
             f"color: {FG_DIM}; font-family: Consolas; font-size: 7pt; "
@@ -126,6 +142,13 @@ class ComponentTable(QWidget):
         row_lay.addWidget(arrow)
 
         self._row_layout.addWidget(container)
+
+    def _open_market(self, item: dict):
+        from dps_ui.market_bubble import MarketBubble
+        bubble = MarketBubble(self.window(), item)
+        bubble.show()
+        bubble.raise_()
+        bubble.activateWindow()
 
     def _open_picker(self):
         popup = ComponentPickerPopup(
@@ -314,7 +337,7 @@ class ComponentPickerPopup(QDialog):
 
     def _populate(self):
         self._model.clear()
-        headers = [_("Sz")] + [h for h, *_ in self._columns]
+        headers = [_("Sz")] + [h for h, *_ in self._columns] + ["\U0001f6d2"]
         self._model.setHorizontalHeaderLabels(headers)
 
         for item in self._items:
@@ -340,10 +363,20 @@ class ComponentPickerPopup(QDialog):
                 si.setTextAlignment(align | Qt.AlignVCenter)
                 row_items.append(si)
 
+            # Cart column — store item ref for click handler
+            cart_item = QStandardItem("\U0001f6d2")
+            cart_item.setData(item, Qt.UserRole + 2)
+            cart_item.setTextAlignment(Qt.AlignCenter | Qt.AlignVCenter)
+            cart_item.setForeground(QColor(FG_DIM))
+            row_items.append(cart_item)
+
             self._model.appendRow(row_items)
 
         # Resize columns
         self._table.resizeColumnsToContents()
+        # Fix cart column width
+        cart_col = len(self._columns) + 1
+        self._table.setColumnWidth(cart_col, 30)
 
     def _apply_filter(self, text):
         self._proxy.setFilterFixedString(text)
@@ -354,9 +387,22 @@ class ComponentPickerPopup(QDialog):
                          else Qt.AscendingOrder)
 
     def _on_row_click(self, proxy_index: QModelIndex):
+        cart_col = len(self._columns) + 1
+        if proxy_index.column() == cart_col:
+            source_row = self._proxy.mapToSource(proxy_index).row()
+            if 0 <= source_row < len(self._items):
+                self._open_market(self._items[source_row])
+            return
         source_row = self._proxy.mapToSource(proxy_index).row()
         if 0 <= source_row < len(self._items):
             self._select(self._items[source_row])
+
+    def _open_market(self, item: dict):
+        from dps_ui.market_bubble import MarketBubble
+        bubble = MarketBubble(self.window(), item)
+        bubble.show()
+        bubble.raise_()
+        bubble.activateWindow()
 
     def _select(self, item):
         self._result_item = item

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -161,6 +161,8 @@ class LauncherWindow(SCWindow):
         grid_rows: int = 3,
         grid_cols: int = 2,
         grid_layout: Optional[Dict[str, str]] = None,
+        scroll_on_hover: bool = False,
+        ui_scale: float = 1.0,
     ) -> None:
         super().__init__(
             title="SC_Toolbox",
@@ -180,6 +182,8 @@ class LauncherWindow(SCWindow):
         self._grid_rows = grid_rows
         self._grid_cols = grid_cols
         self._grid_layout = grid_layout or {}
+        self._scroll_on_hover = scroll_on_hover
+        self._ui_scale = ui_scale
         self._settings_popup: Optional[SettingsPopup] = None
         self._update_bubble: Optional[UpdateBubble] = None
 
@@ -361,6 +365,8 @@ class LauncherWindow(SCWindow):
             current_language=self._current_language,
             available_languages=self._available_languages,
             on_apply=self._on_apply_settings,
+            scroll_on_hover=self._scroll_on_hover,
+            ui_scale=self._ui_scale,
         )
         self._settings_popup.show()
 

--- a/ui/settings_panel.py
+++ b/ui/settings_panel.py
@@ -7,12 +7,12 @@ Grid Layout (customizable NxM grid), and Language selection.
 import logging
 from typing import Callable, Dict, List, Optional
 
-from PySide6.QtCore import Qt, QPoint, QTimer, Signal
-from PySide6.QtGui import QIntValidator
+from PySide6.QtCore import Qt, QPoint, QTimer, Signal, QEvent
+from PySide6.QtGui import QIntValidator, QWheelEvent
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QFrame,
     QSizePolicy, QComboBox, QPushButton, QCheckBox, QGridLayout,
-    QScrollArea, QSpinBox,
+    QScrollArea, QSpinBox, QSlider,
 )
 
 from shared.config_models import SkillConfig
@@ -134,6 +134,82 @@ def _btn_qss(bg: str, bg_hover: str, color: str, color_hover: str = P.fg_bright,
     """
 
 
+# ── Scroll-on-hover helper ─────────────────────────────────────────────────────
+
+from PySide6.QtCore import QObject as _QObject
+
+
+class _HoverWheelFilter(_QObject):
+    """App-level event filter that intercepts wheel events and redirects
+    them to QSpinBox / QSlider widgets under the cursor, even when those
+    widgets don't have focus.
+
+    Installed on ``QApplication.instance()`` so it sees every event before
+    any widget.  Only active when ``_enabled`` is True and the cursor is
+    inside the owning popup.
+    """
+
+    def __init__(self, popup: QWidget):
+        super().__init__(popup)
+        self._enabled = False
+        self._popup = popup
+        self._processing = False  # guard against re-entrant sendEvent
+
+    def set_enabled(self, on: bool):
+        self._enabled = on
+
+    def install(self):
+        """Install on the running QApplication."""
+        from PySide6.QtWidgets import QApplication
+        app = QApplication.instance()
+        if app:
+            app.installEventFilter(self)
+
+    def eventFilter(self, obj, event):
+        if not self._enabled or self._processing:
+            return False
+        if event.type() != QEvent.Wheel:
+            return False
+
+        # Only act when the cursor is inside our popup
+        if not self._popup.isVisible():
+            return False
+
+        from PySide6.QtWidgets import QApplication
+        global_pos = event.globalPosition().toPoint()
+        widget = QApplication.widgetAt(global_pos)
+        if not widget:
+            return False
+
+        # Check the widget itself and its ancestors for a spinbox or slider
+        target = widget
+        while target is not None:
+            if isinstance(target, (QSpinBox, QSlider)):
+                # Found one — give it focus and forward the wheel event
+                self._processing = True
+                target.setFocus(Qt.OtherFocusReason)
+                # Build a new wheel event in the target's local coords
+                local_pos = target.mapFromGlobal(global_pos)
+                redirected = QWheelEvent(
+                    local_pos,
+                    global_pos,
+                    event.pixelDelta(),
+                    event.angleDelta(),
+                    event.buttons(),
+                    event.modifiers(),
+                    event.phase(),
+                    event.inverted(),
+                )
+                QApplication.sendEvent(target, redirected)
+                self._processing = False
+                return True  # consume original
+            if target is self._popup:
+                break  # don't walk past the popup
+            target = target.parentWidget()
+
+        return False
+
+
 # ══════════════════════════════════════════════════════════════════════════════
 # Settings Popup
 # ══════════════════════════════════════════════════════════════════════════════
@@ -155,6 +231,8 @@ class SettingsPopup(QWidget):
         current_language: str = "en",
         available_languages: Optional[List[str]] = None,
         on_apply: Optional[Callable[[dict], None]] = None,
+        scroll_on_hover: bool = False,
+        ui_scale: float = 1.0,
         opacity: float = 0.95,
     ) -> None:
         super().__init__(None, Qt.Tool | Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint)
@@ -177,9 +255,19 @@ class SettingsPopup(QWidget):
         self._grid_rows = grid_rows
         self._grid_cols = grid_cols
         self._grid_layout: Dict[str, str] = dict(grid_layout)
+        self._scroll_on_hover = scroll_on_hover
+        self._ui_scale = ui_scale
         self._language = current_language
 
+        # Scroll-on-hover event filter (app-level)
+        self._wheel_filter = _HoverWheelFilter(self)
+        self._wheel_filter.set_enabled(scroll_on_hover)
+
         self._build_ui()
+
+        # Install on QApplication so it intercepts all wheel events
+        self._wheel_filter.install()
+
         self._select_tab(0)
         self._position_near_parent()
 
@@ -325,7 +413,7 @@ class SettingsPopup(QWidget):
         cancel_btn.clicked.connect(self.close)
         b_lay.addWidget(cancel_btn)
 
-        apply_btn = SCButton(_t("Apply & Restart"), bottom, glow_color=P.green)
+        apply_btn = SCButton(_t("Apply"), bottom, glow_color=P.green)
         apply_btn.setStyleSheet(_btn_qss(
             "#1a3020", "#1f3a28", P.green, font_size="8pt", padding="5px 14px",
         ))
@@ -420,6 +508,84 @@ class SettingsPopup(QWidget):
             label = f"{skill.icon} {skill.name}"
             enabled = skill.id not in self._disabled
             self._make_tool_row(c_lay, skill.id, label, self._skill_hotkeys.get(skill.id, skill.hotkey), show_toggle=True, enabled=enabled)
+
+        # ── Scroll on hover toggle ────────────────────────────────────────
+        scroll_sep = QFrame()
+        scroll_sep.setFixedHeight(1)
+        scroll_sep.setStyleSheet(f"background-color: {P.border};")
+        c_lay.addWidget(scroll_sep)
+
+        scroll_row = QWidget()
+        scroll_row.setFixedHeight(32)
+        scroll_row.setStyleSheet("background: transparent;")
+        scr_lay = QHBoxLayout(scroll_row)
+        scr_lay.setSpacing(8)
+        scr_lay.setContentsMargins(0, 0, 0, 0)
+
+        scroll_lbl = QLabel(_t("Scroll on hover"))
+        scroll_lbl.setStyleSheet(f"""
+            font-family: Consolas; font-size: 9pt;
+            color: {P.fg}; background: transparent;
+        """)
+        scr_lay.addWidget(scroll_lbl)
+
+        scroll_desc = QLabel(_t("Mouse wheel adjusts sliders and spinboxes on hover"))
+        scroll_desc.setStyleSheet(f"""
+            font-family: Consolas; font-size: 7pt;
+            color: {P.fg_disabled}; background: transparent;
+        """)
+        scr_lay.addWidget(scroll_desc, stretch=1)
+
+        self._scroll_hover_check = QCheckBox()
+        self._scroll_hover_check.setChecked(self._scroll_on_hover)
+        self._scroll_hover_check.setStyleSheet(_TOGGLE_QSS)
+        self._scroll_hover_check.toggled.connect(self._wheel_filter.set_enabled)
+        scr_lay.addWidget(self._scroll_hover_check)
+
+        c_lay.addWidget(scroll_row)
+
+        # ── UI Scale ─────────────────────────────────────────────────────
+        scale_sep = QFrame()
+        scale_sep.setFixedHeight(1)
+        scale_sep.setStyleSheet(f"background-color: {P.border};")
+        c_lay.addWidget(scale_sep)
+
+        scale_row = QWidget()
+        scale_row.setFixedHeight(32)
+        scale_row.setStyleSheet("background: transparent;")
+        sc_lay = QHBoxLayout(scale_row)
+        sc_lay.setSpacing(8)
+        sc_lay.setContentsMargins(0, 0, 0, 0)
+
+        scale_lbl = QLabel(_t("UI Scale"))
+        scale_lbl.setStyleSheet(f"""
+            font-family: Consolas; font-size: 9pt;
+            color: {P.fg}; background: transparent;
+        """)
+        sc_lay.addWidget(scale_lbl)
+
+        scale_desc = QLabel(_t("Scale all UI elements for high-res monitors"))
+        scale_desc.setStyleSheet(f"""
+            font-family: Consolas; font-size: 7pt;
+            color: {P.fg_disabled}; background: transparent;
+        """)
+        sc_lay.addWidget(scale_desc, stretch=1)
+
+        self._scale_combo = QComboBox()
+        self._scale_combo.setStyleSheet(_COMBO_QSS)
+        self._scale_combo.setFixedWidth(80)
+        self._scale_combo.setFixedHeight(24)
+        _scale_values = [0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0]
+        for val in _scale_values:
+            self._scale_combo.addItem(f"{val:.2g}x", val)
+        idx = self._scale_combo.findData(self._ui_scale)
+        if idx >= 0:
+            self._scale_combo.setCurrentIndex(idx)
+        else:
+            self._scale_combo.setCurrentIndex(1)  # default 1.0x
+        sc_lay.addWidget(self._scale_combo)
+
+        c_lay.addWidget(scale_row)
 
         c_lay.addStretch(1)
         scroll.setWidget(content)
@@ -704,8 +870,14 @@ class SettingsPopup(QWidget):
                 grid_layout[cell_key] = sid
         result["grid_layout"] = grid_layout
 
+        # Scroll on hover
+        result["scroll_on_hover"] = self._scroll_hover_check.isChecked()
+
         # Language
         result["language"] = self._lang_combo.currentData() or "en"
+
+        # UI Scale
+        result["ui_scale"] = self._scale_combo.currentData() or 1.0
 
         # Validate hotkeys
         for key, val in [("launcher", result["hotkey_launcher"])] + [(k, v) for k, v in skill_hotkeys.items()]:
@@ -713,13 +885,12 @@ class SettingsPopup(QWidget):
                 self._show_status(f"\u2717 {_t('Invalid hotkey')}: {val}", P.red)
                 return
 
-        self._show_status(f"\u2713 {_t('Applying settings and restarting...')}", P.green)
+        # Close popup before relaunch so it doesn't float orphaned
+        # after the parent launcher window has already closed.
+        self.close()
 
         if self._on_apply:
             self._on_apply(result)
-
-        self.applied.emit(result)
-        QTimer.singleShot(300, self.close)
 
     def _show_status(self, msg: str, color: str):
         self._status_label.setText(msg)


### PR DESCRIPTION
## Summary
- Add "Check for Updates" button and auto-check at startup via GitHub Releases/Tags API
- Add "GitHub" link button to launcher title bar
- Add opacity slider to title bar with debounced persistence across sessions
- Add UI scale setting and scroll-on-hover option to settings panel
- Add DPS Calculator market bubble widget
- Enhance settings panel with new configuration options

## Test plan
- [ ] Launch the toolbox and verify the GITHUB and UPDATE buttons appear in the title bar
- [ ] Click GITHUB button — should open the repo in the browser
- [ ] Click UPDATE button — should show "Up to date" or update popup
- [ ] Verify auto-update check runs ~2s after launch (check logs)
- [ ] Test opacity slider in title bar — verify it persists across restarts
- [ ] Test UI scale setting in settings panel
- [ ] Verify DPS Calculator market bubble renders correctly